### PR TITLE
Refact The election-office Relationship

### DIFF
--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -55,7 +55,6 @@ class OfficesController < ApplicationController
       :name,
       :num_of_seats,
       :needs_vice,
-      :election_id
     )
   end
 end

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -3,6 +3,7 @@
 class Election < ApplicationRecord
   has_many :office
   has_and_belongs_to_many :parties
+  has_and_belongs_to_many :offices
 
   # title validations
   validates :title, presence: true

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Office < ApplicationRecord
-  belongs_to :election
+  has_and_belongs_to_many :elections
 
   # name validations
   validates :name, presence: true

--- a/db/migrate/20250303204958_remove_election_id_from_offices.rb
+++ b/db/migrate/20250303204958_remove_election_id_from_offices.rb
@@ -1,0 +1,5 @@
+class RemoveElectionIdFromOffices < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :offices, :election_id, :integer
+  end
+end

--- a/db/migrate/20250303205130_create_join_table_election_offices.rb
+++ b/db/migrate/20250303205130_create_join_table_election_offices.rb
@@ -1,0 +1,10 @@
+class CreateJoinTableElectionOffices < ActiveRecord::Migration[7.1]
+  def change
+    create_join_table :elections, :offices do |t|
+      t.index [:election_id, :office_id]
+      t.index [:office_id, :election_id]
+    end
+
+    add_index :elections_offices, [:election_id, :office_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,75 +10,78 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_250_228_210_200) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_03_205130) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'active_storage_attachments', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
-    t.datetime 'created_at', null: false
-    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
-    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
-                                                    unique: true
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table 'active_storage_blobs', force: :cascade do |t|
-    t.string 'key', null: false
-    t.string 'filename', null: false
-    t.string 'content_type'
-    t.text 'metadata'
-    t.string 'service_name', null: false
-    t.bigint 'byte_size', null: false
-    t.string 'checksum'
-    t.datetime 'created_at', null: false
-    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table 'active_storage_variant_records', force: :cascade do |t|
-    t.bigint 'blob_id', null: false
-    t.string 'variation_digest', null: false
-    t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table 'elections', force: :cascade do |t|
-    t.string 'title'
-    t.text 'description'
-    t.integer 'status', default: 0, null: false
-    t.datetime 'start_time'
-    t.datetime 'end_time'
-    t.date 'election_day'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "elections", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.integer "status", default: 0, null: false
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.date "election_day"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'elections_parties', id: false, force: :cascade do |t|
-    t.bigint 'election_id', null: false
-    t.bigint 'party_id', null: false
+  create_table "elections_offices", id: false, force: :cascade do |t|
+    t.bigint "election_id", null: false
+    t.bigint "office_id", null: false
+    t.index ["election_id", "office_id"], name: "index_elections_offices_on_election_id_and_office_id"
+    t.index ["office_id", "election_id"], name: "index_elections_offices_on_office_id_and_election_id"
   end
 
-  create_table 'offices', force: :cascade do |t|
-    t.string 'name'
-    t.integer 'num_of_seats'
-    t.boolean 'needs_vice'
-    t.bigint 'election_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['election_id'], name: 'index_offices_on_election_id'
+  create_table "elections_parties", id: false, force: :cascade do |t|
+    t.bigint "election_id", null: false
+    t.bigint "party_id", null: false
   end
 
-  create_table 'parties', force: :cascade do |t|
-    t.string 'name'
-    t.string 'abbreviation'
-    t.integer 'party_number'
-    t.text 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "offices", force: :cascade do |t|
+    t.string "name"
+    t.integer "num_of_seats"
+    t.boolean "needs_vice"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'offices', 'elections'
+  create_table "parties", force: :cascade do |t|
+    t.string "name"
+    t.string "abbreviation"
+    t.integer "party_number"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end

--- a/spec/factories/election.rb
+++ b/spec/factories/election.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     start_time { 1.day.from_now }
     end_time { 2.days.from_now }
     election_day { Time.zone.today + 1.week }
+
+    after(:build) do |election|
+      election.offices << build(:office)
+    end
   end
 end

--- a/spec/factories/office.rb
+++ b/spec/factories/office.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     name { 'President' }
     num_of_seats { 1 }
     needs_vice { false }
-    association :election
   end
 end

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -92,13 +92,4 @@ RSpec.describe 'Office', type: :model do
       end
     end
   end
-
-  describe 'election_id validations' do
-    context 'negative validations' do
-      it 'is not valid when election_id is nil' do
-        office.election = nil
-        expect(office).to_not be_valid
-      end
-    end
-  end
 end

--- a/spec/requests/offices_spec.rb
+++ b/spec/requests/offices_spec.rb
@@ -10,14 +10,15 @@ RSpec.describe 'Offices', type: :request do
       name: 'President',
       num_of_seats: 1,
       needs_vice: false,
+      election_ids: [election.id]
     } }
   end
 
   let(:invalid_params) do
     { office: {
-      name: 'President',
-      num_of_seats: 1,
-      needs_vice: false,
+      name: nil,
+      num_of_seats: 0,
+      needs_vice: nil,
     } }
   end
 

--- a/spec/requests/offices_spec.rb
+++ b/spec/requests/offices_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Offices', type: :request do
       name: 'President',
       num_of_seats: 1,
       needs_vice: false,
-      election_id: election.id
     } }
   end
 
@@ -19,7 +18,6 @@ RSpec.describe 'Offices', type: :request do
       name: 'President',
       num_of_seats: 1,
       needs_vice: false,
-      election_id: nil
     } }
   end
 


### PR DESCRIPTION
# [REFAC] Update Election-Office Relationship & Fix Controller Errors

## Description
This pull request refactors the association between the `Election` and `Office` models, moving from a one-to-many relationship to a many-to-many relationship. In addition, errors in the `OfficesController` have been fixed.

### Key Changes:
- **Relationship Refactor:**
  - Updated the `Election` model to use `has_and_belongs_to_many :offices` (replacing the previous `has_many :office`).
  - Modified the `Office` model to add a many-to-many association with elections via `has_and_belongs_to_many :elections`.
  - Created a migration to remove the `election_id` column from the `offices` table.
  - Added a migration to create the join table `elections_offices` with proper indices and uniqueness constraints.
  - Adjusted model factories and tests to accommodate the new relationship structure.

- **Controller Fix:**
  - Resolved errors in the `OfficesController` by removing the `:election_id` parameter from the permitted parameters in the `office_params` method.

## Commits Included
- `refact: change relationship between election and office`
- `fix: office controller errors`
