### PR TITLE
Implementation the Controller of Candidate Entity

### DIFF
--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -1,0 +1,22 @@
+class CandidatesController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -1,22 +1,61 @@
 class CandidatesController < ApplicationController
   def index
+    @candidates = Candidate.all
   end
 
   def show
+    @candidate = Candidate.find_by(id: params[:id])
+    return if @candidate
+
+    head :not_found
   end
 
   def new
+    @candidate = Candidate.new
   end
 
   def create
+    @candidate = Candidate.new(candidate_params)
+    return render :new, status: :unprocessable_entity unless @candidate.save
+
+    redirect_to @candidate 
   end
 
   def edit
+    @candidate = Candidate.find_by(id: params[:id])
+    return if @candidate
+
+    head :not_found
   end
 
   def update
+    @candidate = Candidate.find_by(id: params[:id])
+
+    return head :not_found unless @candidate
+
+    return render :edit, status: :unprocessable_entity unless @candidate.update(candidate_params)
+
+    redirect_to @candidate
   end
 
   def destroy
+    @candidate = Candidate.find_by(id: params[:id])
+
+    return head :not_found unless @candidate
+
+    @candidate.destroy
+    redirect_to candidates_path
+  end
+
+  private
+
+  def candidate_params
+    params.require(:candidate).permit(
+      :name,
+      :candidate_num,
+      :election_id,
+      :office_id,
+      :party_id
+    )
   end
 end

--- a/app/helpers/candidates_helper.rb
+++ b/app/helpers/candidates_helper.rb
@@ -1,0 +1,2 @@
+module CandidatesHelper
+end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -17,6 +17,9 @@ class Candidate < ApplicationRecord
   # profile photo
   validate :profile_pic_content_type_and_size
 
+  # relationships
+  validates :election, :office, :party, presence: true
+
   private
 
   def profile_pic_content_type_and_size

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -3,7 +3,7 @@
 class Election < ApplicationRecord
   has_and_belongs_to_many :parties
   has_and_belongs_to_many :offices
-  has_and_belongs_to_many :candidates
+  has_many :candidates
 
   # title validations
   validates :title, presence: true

--- a/app/views/candidates/create.html.erb
+++ b/app/views/candidates/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Candidates#create</h1>
+<p>Find me in app/views/candidates/create.html.erb</p>

--- a/app/views/candidates/destroy.html.erb
+++ b/app/views/candidates/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Candidates#destroy</h1>
+<p>Find me in app/views/candidates/destroy.html.erb</p>

--- a/app/views/candidates/edit.html.erb
+++ b/app/views/candidates/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Candidates#edit</h1>
+<p>Find me in app/views/candidates/edit.html.erb</p>

--- a/app/views/candidates/index.html.erb
+++ b/app/views/candidates/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Candidates#index</h1>
+<p>Find me in app/views/candidates/index.html.erb</p>

--- a/app/views/candidates/new.html.erb
+++ b/app/views/candidates/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Candidates#new</h1>
+<p>Find me in app/views/candidates/new.html.erb</p>

--- a/app/views/candidates/show.html.erb
+++ b/app/views/candidates/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Candidates#show</h1>
+<p>Find me in app/views/candidates/show.html.erb</p>

--- a/app/views/candidates/update.html.erb
+++ b/app/views/candidates/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Candidates#update</h1>
+<p>Find me in app/views/candidates/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get 'candidates/index'
+  get 'candidates/show'
+  get 'candidates/new'
+  get 'candidates/create'
+  get 'candidates/edit'
+  get 'candidates/update'
+  get 'candidates/destroy'
   resources :elections
   resources :offices
   resources :parties

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'candidates/index'
-  get 'candidates/show'
-  get 'candidates/new'
-  get 'candidates/create'
-  get 'candidates/edit'
-  get 'candidates/update'
-  get 'candidates/destroy'
   resources :elections
   resources :offices
   resources :parties
+  resources :candidates
   get 'up' => 'rails/health#show', as: :rails_health_check
 end

--- a/spec/helpers/candidates_helper_spec.rb
+++ b/spec/helpers/candidates_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CandidatesHelper. For example:
+#
+# describe CandidatesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CandidatesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/candidates_spec.rb
+++ b/spec/requests/candidates_spec.rb
@@ -1,53 +1,139 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Candidates", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/candidates/index"
-      expect(response).to have_http_status(:success)
+RSpec.describe 'Candidates', type: :request do
+  let!(:election) { create(:election) }
+  let!(:office) { create(:office) }
+  let!(:party) { create(:party) }
+
+  let(:valid_params) do
+    { candidate: {
+      name: 'Danilo Martins',
+      candidate_num: '18',
+      election_id: election.id,
+      office_id: office.id,
+      partry_id: party.id
+    } }
+  end
+
+  let(:invalid_params) do
+    { candidate: {
+      name: nil,
+      candidate_num: 0,
+    } }
+  end
+
+  # GET /index
+  describe 'GET /candidates' do
+    let!(:candidate) { create(:candidate) }
+
+    it 'returns a list of candidates' do
+      get '/candidates'
+      expect(response).to have_http_status(:ok)
     end
   end
 
-  describe "GET /show" do
-    it "returns http success" do
-      get "/candidates/show"
-      expect(response).to have_http_status(:success)
+  # GET /show
+  describe 'GET /candidates/:id' do
+    context 'when candidate exists (ID valid)' do
+      let!(:candidate) { create(:candidate) }
+
+      it 'return candidate details' do
+        get "/candidates/#{candidate.id}"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when candidates does NOT exists (ID invalid)' do
+      it 'returns a 404 not found' do
+        get '/candidates/9999999999'
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 
-  describe "GET /new" do
-    it "returns http success" do
-      get "/candidates/new"
-      expect(response).to have_http_status(:success)
+  # GET /new (form)
+  describe 'GET /candidates/new' do
+    it 'renders a form for creating a new candidate' do
+      get '/candidates/new'
+      expect(response).to have_http_status(:ok)
     end
   end
 
-  describe "GET /create" do
-    it "returns http success" do
-      get "/candidates/create"
-      expect(response).to have_http_status(:success)
+  # POST /create
+  describe 'POST /candidates' do
+    context 'with valid params' do
+      it 'creates a new candidate and redirects' do
+        post '/candidates', params: valid_params
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context 'with invalid params' do
+      it 'does not creates a new candidate, renders form with errors' do
+        post '/candidates', params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 
-  describe "GET /edit" do
-    it "returns http success" do
-      get "/candidates/edit"
-      expect(response).to have_http_status(:success)
+  # GET /edit
+  describe 'GET /candidates/:id/edit' do
+    context 'when candidate exists (ID valid)' do
+      let!(:candidate) { create(:candidate) }
+
+      it 'renders a form for editing an existing candidate' do
+        get "/candidates/#{candidate.id}/edit"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when candidates does NOT exists (ID invalid)' do
+      it 'returns a 404 not found' do
+        get '/candidates/9999999999'
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 
-  describe "GET /update" do
-    it "returns http success" do
-      get "/candidates/update"
-      expect(response).to have_http_status(:success)
+  # PUT /update
+  describe 'PATCH /candidates/:id' do
+    context 'with valid params' do
+      let!(:candidate) { create(:candidate) }
+
+      it 'updates existing candidate and redirects' do
+        patch "/candidates/#{candidate.id}", params: valid_params
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context 'with invalid params' do
+      let!(:candidate) { create(:candidate) }
+      it 'does not update the candidate, renders form with errors' do
+        patch "/candidates/#{candidate.id}", params: invalid_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/candidates/destroy"
-      expect(response).to have_http_status(:success)
+  # DELETE /destroy
+  describe 'DELETE /candidates/:id' do
+    context 'when candidate exists (ID valid)' do
+      let!(:candidate) { create(:candidate) }
+
+      it 'delete candidate and redirects' do
+        delete "/candidates/#{candidate.id}"
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context 'when candidates does NOT exists (ID invalid)' do
+      it 'returns a 404 not found' do
+        delete '/candidates/9999999999'
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
-
 end
+

--- a/spec/requests/candidates_spec.rb
+++ b/spec/requests/candidates_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Candidates', type: :request do
       candidate_num: '18',
       election_id: election.id,
       office_id: office.id,
-      partry_id: party.id
+      party_id: party.id
     } }
   end
 

--- a/spec/requests/candidates_spec.rb
+++ b/spec/requests/candidates_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "Candidates", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/candidates/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/candidates/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/candidates/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/candidates/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/candidates/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/candidates/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/candidates/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/candidates/create.html.erb_spec.rb
+++ b/spec/views/candidates/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/candidates/destroy.html.erb_spec.rb
+++ b/spec/views/candidates/destroy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/destroy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/candidates/edit.html.erb_spec.rb
+++ b/spec/views/candidates/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/candidates/index.html.erb_spec.rb
+++ b/spec/views/candidates/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/candidates/new.html.erb_spec.rb
+++ b/spec/views/candidates/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/candidates/show.html.erb_spec.rb
+++ b/spec/views/candidates/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/candidates/update.html.erb_spec.rb
+++ b/spec/views/candidates/update.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/update.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# [FEATURE] Add CandidatesController (CRUD) & Fix Election‑Candidate Relationship

## Description
This pull request introduces a full CRUD interface for the `Candidate` resource and corrects the association between `Election` and `Candidate`. It also refactors and completes request specs to ensure all endpoints behave as expected.

### Key Changes

- **CandidatesController**  
  - Generated via `rails generate controller candidates`  
  - Implemented standard RESTful actions: `index`, `show`, `new`, `create`, `edit`, `update`, `destroy`  
  - Added strong parameter whitelisting for `:name`, `:candidate_num`, `:election_id`, `:office_id`, and `:party_id`

- **Views**  
  - Created placeholder ERB templates for each CRUD action under `app/views/candidates`

- **Routes**  
  - Registered `resources :candidates` in `config/routes.rb`

- **Model Association Fix**  
  - Updated `Election` model to use `has_many :candidates` instead of a HABTM relationship  
  - Ensured `Candidate` belongs to `Election`, `Office`, and `Party`

- **Tests**  
  - Refactored and expanded `spec/requests/candidates_spec.rb` to cover all success and failure scenarios for CRUD operations  
  - Added pending view specs and helper spec stubs

## Commits Included

- `feat(candidate): run rails generate controller`  
- `refact(candidate controller): refactor candidates_spec tests`  
- `fix(candidate controller): green stage`  
- `fix(election): correct association between candidate and election`

## Verification

- All request specs for `Candidate` pass (HTTP 200/302 for valid requests, 404 or 422 for invalid IDs/params)  
- Model associations and validations enforce referential integrity  
- Routes and controller actions respond correctly to CRUD requests  
